### PR TITLE
Fix browser error

### DIFF
--- a/src/utils/bytes32.ts
+++ b/src/utils/bytes32.ts
@@ -2,7 +2,7 @@ import invariant from "tiny-invariant";
 
 export const toBytes32Array = (b: Buffer): number[] => {
   invariant(b.length <= 32, `invalid length ${b.length}`);
-  const buf = new Uint8Array(Buffer.alloc(32));
+  const buf = Buffer.alloc(32);
   b.copy(buf, 32 - b.length);
 
   return Array.from(buf);


### PR DESCRIPTION
The `new Uint8Array` bit seems redundant and causes next.js to fail (`Buffer.copy` will not see Uint8Array as a Buffer in the next.js polyfill)