### PR TITLE
Add ability to claim on behalf of claimant

### DIFF
--- a/scripts/create-distributor.ts
+++ b/scripts/create-distributor.ts
@@ -58,8 +58,10 @@ const main = async () => {
   const sdk = MerkleDistributorSDK.load({ provider });
   invariant(process.env.MINT_KEYFILE, "mint keyfile not found");
   const mintKeypair = readKeyfile(process.env.MINT_KEYFILE);
+  const authClaimantOwner = process.env.AUTH_CLAIMANT_OWNER || true;
 
   const pendingDistributor = await sdk.createDistributor({
+    authClaimantOwner,
     root: merkleRoot,
     maxTotalClaim: new u64(tokenTotal),
     maxNumNodes: new u64(Object.keys(claims).length),

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export type CreateDistributorArgs = {
   maxNumNodes: u64;
   tokenMint: PublicKey;
   base?: Keypair;
+  authClaimantOwner: Boolean,
 };
 
 export type PendingDistributor = {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -69,6 +69,7 @@ export class MerkleDistributorWrapper {
         toBytes32Array(root),
         args.maxTotalClaim,
         args.maxNumNodes,
+        args.authClaimantOwner,
         {
           accounts: {
             base: baseKey.publicKey,


### PR DESCRIPTION
Allowing anyone to claim tokens to go to an account that has rights to that claim gives more flexibility on the operational side of things. If a single entity has multiple claims spread across different accounts, a simple script could iterate and claim on behalf of each wallet with one account signer.