### PR TITLE
add mut constraint to payers

### DIFF
--- a/programs/merkle-distributor/src/lib.rs
+++ b/programs/merkle-distributor/src/lib.rs
@@ -163,6 +163,7 @@ pub struct NewDistributor<'info> {
     pub mint: Account<'info, Mint>,
 
     /// Payer to create the distributor.
+    #[account(mut)]
     pub payer: Signer<'info>,
 
     /// The [System] program.
@@ -202,6 +203,7 @@ pub struct Claim<'info> {
     pub claimant: Signer<'info>,
 
     /// Payer of the claim.
+    #[account(mut)]
     pub payer: Signer<'info>,
 
     /// The [System] program.


### PR DESCRIPTION
the reason this has not been breaking your tests is because your provider happened to be the tx's fee payer and was mut anyway